### PR TITLE
Add std string typedef

### DIFF
--- a/source/grv/System.hpp
+++ b/source/grv/System.hpp
@@ -1,4 +1,5 @@
 #include <windows.h>
+#include <string>
 
 #if (defined(__cplusplus) && __cplusplus == 201103L) || (defined(_MSC_VER) && _MSC_VER >= 1800)
 #define CPP11 1 // the compiler has support for C++11
@@ -25,4 +26,7 @@ namespace grv
 	// Float typedefs
 	typedef float f32;
 	typedef double f64;
+
+	// String typedefs
+	typedef std::string str;
 }


### PR DESCRIPTION
We took the decision to use std string since we don't think the performance overhead will be a problem compared to the useability we gain.
